### PR TITLE
add new heading pattern "I/E."

### DIFF
--- a/screenplay_pdf_to_json/utils/headingHelpers.py
+++ b/screenplay_pdf_to_json/utils/headingHelpers.py
@@ -1,6 +1,6 @@
 import re
 
-headingEnum = ["EXT./INT.", "EXT./INT.", "INT./EXT.", "EXT/INT","INT/EXT", "INT.", "EXT.", "INT --", "EXT --"]
+headingEnum = ["EXT./INT.", "EXT/INT.", "INT./EXT.", "EXT/INT","INT/EXT", "INT.", "EXT.", "INT --", "EXT --", "I/E."]
 
 
 def isHeading(content):
@@ -48,9 +48,10 @@ def extractHeading(text):
         INT.
         EXT --
         INT --
+        I/E.
     """
     region = re.search(
-        '((?:.* )?(?:EXT[\\.]?\\/INT[\\.]?|INT[\\.]?\\/EXT[\\.]?|INT(?:\\.| --)|EXT(?:\\.| --)))', text).groups()[0]
+        r'((?:.* )?(?:EXT[\.]?\/INT[\.]?|INT[\.]?\/EXT[\.]?|INT(?:\.| --)|EXT(?:\.| --)|I\/E\.))', text).groups()[0]
     time = extractTime(text)
 
 


### PR DESCRIPTION
Passed the tests on a subset of Oscar 2023. The subset includes:

- a-man-called-otto
- aftersun
- all-quiet-on-the-western-front
- black-panther-wakanda-forever
- living
- the-banshees-of-inisherin
- the-fabelmans
- the-whale
- the-woman-king
- till
- top-gun-maverick
- triangle-of-sadness
- white-noise
- women-talking